### PR TITLE
Xử lý exception cho TST

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
@@ -1,6 +1,7 @@
 package net.minevn.dotman.providers
 
 import net.minevn.dotman.DotMan
+import net.minevn.dotman.DotMan.Companion.transactional
 import net.minevn.dotman.TOP_KEY_DONATE_TOTAL
 import net.minevn.dotman.TOP_KEY_POINT_FROM_CARD
 import net.minevn.dotman.card.Card
@@ -92,7 +93,7 @@ abstract class CardProvider {
         onChargeSuccess(player, result.card)
     }
 
-    protected open fun onChargeSuccess(player: Player, card: Card) {
+    protected open fun onChargeSuccess(player: Player, card: Card) = transactional {
         var amount = card.price.getPointAmount()
         val config = main.config
         val extraRate = config.extraRate

--- a/dotman-plugin/src/main/java/net/minevn/dotman/providers/types/TheSieuTocCP.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/providers/types/TheSieuTocCP.kt
@@ -3,6 +3,7 @@ package net.minevn.dotman.providers.types
 import net.minevn.dotman.card.*
 import net.minevn.dotman.database.LogDAO
 import net.minevn.dotman.providers.CardProvider
+import net.minevn.dotman.utils.Utils.Companion.severe
 import net.minevn.libs.bukkit.getOrNull
 import net.minevn.libs.bukkit.parseJson
 import net.minevn.libs.bukkit.sendMessages
@@ -94,7 +95,12 @@ class TheSieuTocCP(private val apiKey: String, private val apiSecret: String) : 
                 cardLogger.stopWaiting(it.id, it.isSuccess)
 
                 if (it.isSuccess) {
-                    onChargeSuccess(player, it.toCard())
+                    try {
+                        onChargeSuccess(player, it.toCard())
+                    } catch (e: Exception) {
+                        player.sendMessages(lang.cardChargedError)
+                        e.severe("Error onChargeSuccess: Player ${player.name}, ${it.toCard()}")
+                    }
                 } else {
                     val message = it.message ?: lang.errorUnknown
                     player.sendMessages(lang.cardChargedFailed.map { str ->


### PR DESCRIPTION
## Thay đổi nhỏ
- Chuyển hàm `onChargeSuccess` sang transaction.
- Xử lý exception cho TST: Nếu cộng point lỗi thì gửi thông báo đến player và print exception.