### PR TITLE
Fix lỗi không cập nhật số point trong lịch sử (TST)

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/card/CardWaiting.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/card/CardWaiting.kt
@@ -10,5 +10,5 @@ class CardWaiting(
     var isSuccess: Boolean = false
     var message: String? = null
 
-    fun toCard() = Card(seri, "", CardPrice[price]!!, CardType[type]!!)
+    fun toCard() = Card(seri, "", CardPrice[price]!!, CardType[type]!!).apply { logId = id }
 }


### PR DESCRIPTION
Cập nhật logId sau khi xét TST

- [x] Test: Nạp qua TST: Số point của logId tương ứng đã được cập nhật