### PR TITLE
Điều chỉnh native support thành 1.20

### DIFF
--- a/dotman-plugin/build.gradle.kts
+++ b/dotman-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     // spigot
-    compileOnly("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
 
     // libs
     compileOnly("net.minevn:minevnlib-plugin:1.0.4")

--- a/dotman-plugin/src/main/java/net/minevn/dotman/DotMan.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/DotMan.kt
@@ -75,7 +75,7 @@ class DotMan : MineVNPlugin(), Listener {
     fun reload() {
         config = MainConfig()
         prefix = config.prefix
-        initDatabase(config.config.getConfigurationSection("database"))
+        initDatabase(config.config.getConfigurationSection("database")!!)
         migrate()
         language = Language()
         minestones = Milestones()

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/MainConfig.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/MainConfig.kt
@@ -16,7 +16,7 @@ class MainConfig : FileConfig("config") {
     val dbEngine = config.getString("database.engine", "h2")!!
     val provider = config.getString("provider", "")!!
     val server = config.getString("server", "")!!
-    val cardTypes = config.getConfigurationSection("card-types").run {
+    val cardTypes = config.getConfigurationSection("card-types")!!.run {
         CardType.entries.associateWith { getBoolean(it.name.lowercase()) }
     }
 

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
@@ -17,7 +17,7 @@ class Milestones : FileConfig("mocnap") {
     @Suppress("UNCHECKED_CAST")
     private fun loadComponents() {
         var premiumWarning = false
-        components = config.getList("mocnap").map {
+        components = (config.getList("mocnap") ?: emptyList()).map {
             try {
                 it as Map<*, *>
                 val component = Component(it["type"] as String, it["amount"] as Int, it["commands"] as List<String>)

--- a/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
@@ -20,7 +20,7 @@ import org.bukkit.entity.Player
 
 abstract class CardProvider {
     val task = Bukkit.getScheduler()
-        .runTaskTimerAsynchronously(DotMan.instance, ::updateStatus, 0L, 20 * 60)!!
+        .runTaskTimerAsynchronously(DotMan.instance, ::updateStatus, 0L, 20 * 60)
 
     companion object {
         lateinit var instance: CardProvider private set
@@ -32,15 +32,15 @@ abstract class CardProvider {
 
             instance = when (provider) {
                 "thesieutoc" -> {
-                    val apiKey = config.getString("api-key")
-                    val apiSecret = config.getString("api-secret")
+                    val apiKey = config.getString("api-key")!!
+                    val apiSecret = config.getString("api-secret")!!
                     TheSieuTocCP(apiKey, apiSecret)
                 }
 
                 "gamebank" -> {
                     val merchantID = config.getInt("merchant_id")
-                    val apiUser = config.getString("api_user")
-                    val apiPassword = config.getString("api_password")
+                    val apiUser = config.getString("api_user")!!
+                    val apiPassword = config.getString("api_password")!!
                     GameBankCP(merchantID, apiUser, apiPassword)
                 }
 

--- a/dotman-plugin/src/main/resources/config.yml
+++ b/dotman-plugin/src/main/resources/config.yml
@@ -46,7 +46,7 @@ manual:
   # Số point được nhận thêm trên mõi 1000 VNĐ khi nạp qua ngân hàng
   # Mặc định: 1000 VNĐ = 0.5 point
   point-extra: 0.5
-  # Công thức tính khi nạp qua ngân hàng:
+  # Công thức tính khi nạp qua lệnh nạp thủ công:
   # - Số point nhận được = Số point tiêu chuẩn + Số point được nhận thêm + (Số point tiêu chuẩn ⅹ Khuyến mãi)
   # Trong đó khuyến mãi là giá trị khuyến mãi được định nghĩa trong config.yml
   # Ví dụ: Nếu bạn đặt point tiêu chuẩn và nhận thêm là mặc định (1 và 0.5) và bạn đang bật khuyến mãi 50% (GTKM 0.5) thì:

--- a/dotman-plugin/src/main/resources/plugin.yml
+++ b/dotman-plugin/src/main/resources/plugin.yml
@@ -1,4 +1,5 @@
 name: DotMan
+api-version: 1.20
 main: net.minevn.dotman.DotMan
 version: '${version}'
 author: MineVN


### PR DESCRIPTION
## Nội dung
- Điều chỉnh native support thành 1.20
  - Nâng spigot version lên 1.20.4
  - Thêm null check `!!` vào một số nơi: Những điểm này API được điều chỉnh thành `Nullable` nên phải thêm `!!` để có thể compile được

## Nguyên nhân
- Plugin không nhận biết được các Material của phiên bản 1.13 trở lên: mọi material type đều trở thành AIR
  - Đã thử XMaterial những vẫn không được

## Tests
- Plugin hoạt động bình thường
- Đã test các tính năng sau trên phiên bản 1.12.2 và 1.20.4
  - [x] Nạp thẻ
  - [x] Giao diện nạp
  - [x] Top nạp
  - [x] Lịch sử nạp