### PR TITLE
Mốc nạp tổng

### DIFF
--- a/dotman-plugin/build.gradle.kts
+++ b/dotman-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
 
     // libs
-    compileOnly("net.minevn:minevnlib-plugin:1.0.4")
+    compileOnly("net.minevn:minevnlib-plugin:1.0.5")
     compileOnly("minevn.depend:playerpoints:3.2.6")
     compileOnly("me.clip:placeholderapi:2.11.3")
 

--- a/dotman-plugin/src/main/java/net/minevn/dotman/LeaderBoard.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/LeaderBoard.kt
@@ -6,7 +6,7 @@ import net.minevn.libs.bukkit.runSync
 import org.bukkit.Bukkit
 import java.util.concurrent.ConcurrentHashMap
 
-const val TOP_EXPIRE = 5 * 60 * 1000L // 5 phút
+const val TOP_EXPIRE = 1 * 60 * 1000L // 1 phút
 const val TOP_COUNT = 100
 
 const val TOP_KEY_DONATE_TOTAL = "DONATE_TOTAL"

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
@@ -3,6 +3,7 @@ package net.minevn.dotman.config
 import net.minevn.dotman.DotMan
 import net.minevn.dotman.TOP_KEY_DONATE_TOTAL
 import net.minevn.dotman.database.PlayerDataDAO
+import net.minevn.dotman.utils.Utils.Companion.format
 import net.minevn.dotman.utils.Utils.Companion.info
 import net.minevn.dotman.utils.Utils.Companion.warning
 import net.minevn.libs.bukkit.runSync
@@ -78,8 +79,8 @@ class Milestones : FileConfig("mocnap") {
                                 runSync { Bukkit.getOnlinePlayers().forEach {addPlayer(it)} }
                             }
                             val title = bossBar
-                                .replace("%CURRENT%", current.toString())
-                                .replace("%TARGET%", amount.toString())
+                                .replace("%CURRENT%", current.format())
+                                .replace("%TARGET%", amount.format())
                             progress = current.toDouble() / amount
                             setTitle(title)
                         } else {

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
@@ -1,10 +1,17 @@
 package net.minevn.dotman.config
 
+import net.minevn.dotman.DotMan
+import net.minevn.dotman.TOP_KEY_DONATE_TOTAL
+import net.minevn.dotman.database.PlayerDataDAO
 import net.minevn.dotman.utils.Utils.Companion.info
 import net.minevn.dotman.utils.Utils.Companion.warning
 import net.minevn.libs.bukkit.runSync
 import org.bukkit.Bukkit
+import org.bukkit.boss.BarColor
+import org.bukkit.boss.BarStyle
+import org.bukkit.boss.BossBar
 import org.bukkit.entity.Player
+import org.bukkit.scheduler.BukkitTask
 
 class Milestones : FileConfig("mocnap") {
 
@@ -42,7 +49,7 @@ class Milestones : FileConfig("mocnap") {
             }
         }.filterNotNull()
 
-        info("Đã nạp ${components.size} mốc nạp")
+        info("Đã nạp ${components.size} mốc nạp.")
     }
 
     override fun reload() {
@@ -52,7 +59,39 @@ class Milestones : FileConfig("mocnap") {
 
     fun getAll() = components.toList()
 
-    class Component(val type: String, val amount: Int, val commands: List<String>) {
+    class Component(val type: String, val amount: Int, val commands: List<String>, val bossBar: String? = null,
+                    val from: Int = 0, barColor : BarColor = BarColor.GREEN,
+                    barStyle: BarStyle = BarStyle.SEGMENTED_10) {
+
+        var bar: BossBar? = null
+        var barTask: BukkitTask? = null; private set
+
+        init {
+            if (bossBar != null) {
+                bar = Bukkit.createBossBar("§r", barColor, barStyle).apply {
+                    isVisible = false
+                    barTask = Bukkit.getScheduler().runTaskTimerAsynchronously(DotMan.instance, Runnable {
+                        val current = PlayerDataDAO.getInstance().getSumData("${TOP_KEY_DONATE_TOTAL}_$type")
+                        if (current in from until amount) {
+                            if (!isVisible) {
+                                isVisible = true
+                                runSync { Bukkit.getOnlinePlayers().forEach {addPlayer(it)} }
+                            }
+                            val title = bossBar
+                                .replace("%CURRENT%", current.toString())
+                                .replace("%TARGET%", amount.toString())
+                            progress = current.toDouble() / amount
+                            setTitle(title)
+                        } else {
+                            if (isVisible) {
+                                removeAll()
+                                isVisible = false
+                            }
+                        }
+                    }, 0, 20 * 5)
+                }
+            }
+        }
 
         private val typeName = when (type) {
             "all" -> "toàn thời gian"
@@ -65,6 +104,7 @@ class Milestones : FileConfig("mocnap") {
          * Kiểm tra xem người chơi đã đạt mốc nạp này chưa,
          * nếu đạt thì thực hiện các lệnh trong config
          *
+         * @param player người chơi
          * @param current số tiền sau khi nạp
          * @param amount số tiền nạp
          */
@@ -74,8 +114,28 @@ class Milestones : FileConfig("mocnap") {
                 runSync {
                     commands.forEach {
                         val command = it.replace("%player%", player.name)
-                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.format(player.name))
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
                     }
+                }
+            }
+        }
+
+        /**
+         * Kiểm tra xem toàn server đã đạt mốc nạp này chưa,
+         * nếu đạt thì thực hiện các lệnh trong config
+         *
+         * @param current số tiền sau khi nạp
+         * @param amount số tiền nạp
+         */
+        fun sumCheck(current: Int, amount: Int) {
+            if (current >= this.amount && current - amount < this.amount) {
+                runSync {
+                    commands.forEach {
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), it)
+                    }
+                    bar?.removeAll()
+                    bar?.isVisible = false
+                    bar = null
                 }
             }
         }

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/MilestonesMaster.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/MilestonesMaster.kt
@@ -5,6 +5,7 @@ import net.minevn.dotman.utils.Utils.Companion.getBarColor
 import net.minevn.dotman.utils.Utils.Companion.getBarStyle
 import net.minevn.dotman.utils.Utils.Companion.info
 import net.minevn.dotman.utils.Utils.Companion.warning
+import net.minevn.libs.bukkit.color
 
 class MilestonesMaster : FileConfig("mocnaptong") {
     private var components: List<Component> = emptyList()
@@ -19,7 +20,7 @@ class MilestonesMaster : FileConfig("mocnaptong") {
         components = (config.getList("mocnaptong") ?: emptyList()).map {
             try {
                 it as Map<*, *>
-                val bossBar = it.getOrDefault("bossbar", null) as String?
+                val bossBar = (it.getOrDefault("bossbar", null) as String?)?.color()
                 val from = it.getOrDefault("from", 0) as Int
                 val barColor = getBarColor(it.getOrDefault("bossbar-color", null) as String?)
                 val barStyle = getBarStyle(it.getOrDefault("bossbar-style", null) as String?)

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/MilestonesMaster.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/MilestonesMaster.kt
@@ -1,0 +1,58 @@
+package net.minevn.dotman.config
+
+import net.minevn.dotman.config.Milestones.Component
+import net.minevn.dotman.utils.Utils.Companion.getBarColor
+import net.minevn.dotman.utils.Utils.Companion.getBarStyle
+import net.minevn.dotman.utils.Utils.Companion.info
+import net.minevn.dotman.utils.Utils.Companion.warning
+
+class MilestonesMaster : FileConfig("mocnaptong") {
+    private var components: List<Component> = emptyList()
+
+    init {
+        loadComponents()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadComponents() {
+        var premiumWarning = false
+        components = (config.getList("mocnaptong") ?: emptyList()).map {
+            try {
+                it as Map<*, *>
+                val bossBar = it.getOrDefault("bossbar", null) as String?
+                val from = it.getOrDefault("from", 0) as Int
+                val barColor = getBarColor(it.getOrDefault("bossbar-color", null) as String?)
+                val barStyle = getBarStyle(it.getOrDefault("bossbar-style", null) as String?)
+                val component = Component(it["type"] as String, it["amount"] as Int, it["commands"] as List<String>,
+                    bossBar, from, barColor, barStyle)
+
+                if (component.type !in listOf("all", "week", "month")) {
+                    warning("Loại mốc nạp \"${component.type}\" không hợp lệ. Chỉ chấp nhận all, week, month")
+                    return@map null
+                }
+                if (component.type != "all") {
+                    if (!premiumWarning) {
+                        premiumWarning = true
+                        warning("Tính năng mốc nạp theo tuần, tháng chỉ có ở phiên bản DotMan premium. " +
+                                "Hãy mua plugin để ủng hộ author nhé!")
+                    }
+                    return@map null
+                }
+
+                component
+            } catch (e: Exception) {
+                e.warning("Có một mốc nạp không hợp lệ, hãy liên hệ developer để được hỗ trợ")
+                null
+            }
+        }.filterNotNull()
+
+        info("Đã nạp ${components.size} mốc nạp tổng.")
+    }
+
+    override fun reload() {
+        super.reload()
+        loadComponents()
+    }
+
+    fun getAll() = components.toList()
+}

--- a/dotman-plugin/src/main/java/net/minevn/dotman/database/PlayerDataDAO.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/database/PlayerDataDAO.kt
@@ -12,6 +12,7 @@ abstract class PlayerDataDAO : DataAccess() {
     abstract fun insertDataScript(): String
     abstract fun getTopScript(): String
     abstract fun getDataScript(): String
+    abstract fun getSumDataScript(): String
 
     fun insertData(uuid: String, key: String, value: Int) {
         insertDataScript().statement {
@@ -28,6 +29,14 @@ abstract class PlayerDataDAO : DataAccess() {
     fun getData(uuid: String, key: String) = getDataScript().statement {
         setString(1, uuid)
         setString(2, key)
+
+        fetchRecords {
+            getInt("value")
+        }.firstOrNull() ?: 0
+    }
+
+    fun getSumData(key: String) = getSumDataScript().statement {
+        setString(1, key)
 
         fetchRecords {
             getInt("value")

--- a/dotman-plugin/src/main/java/net/minevn/dotman/database/h2/PlayerDataDAOImpl.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/database/h2/PlayerDataDAOImpl.kt
@@ -35,4 +35,10 @@ class PlayerDataDAOImpl : PlayerDataDAO() {
         FROM "dotman_player_data"
         WHERE "uuid" = ? AND "key" = ?;
     """.trimIndent()
+
+    override fun getSumDataScript() = """
+        SELECT SUM("value") as "value"
+        FROM "dotman_player_data"
+        WHERE "key" = ?;
+    """.trimIndent()
 }

--- a/dotman-plugin/src/main/java/net/minevn/dotman/database/mysql/PlayerDataDAOImpl.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/database/mysql/PlayerDataDAOImpl.kt
@@ -28,4 +28,10 @@ class PlayerDataDAOImpl : PlayerDataDAO() {
         FROM `dotman_player_data`
         WHERE `uuid` = ? AND `key` = ?;
     """.trimIndent()
+
+    override fun getSumDataScript() = """
+        SELECT SUM(`value`) as `value`
+        FROM `dotman_player_data`
+        WHERE `key` = ?;
+    """.trimIndent()
 }

--- a/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
@@ -11,6 +11,7 @@ import org.bukkit.boss.BarColor
 import org.bukkit.boss.BarStyle
 import org.bukkit.command.CommandSender
 import org.bukkit.scheduler.BukkitTask
+import java.text.DecimalFormat
 import java.util.logging.Level
 
 class Utils {
@@ -91,5 +92,14 @@ class Utils {
 
         fun getBarStyle(str : String?) = BarStyle.entries.firstOrNull { it.name.equals(str, true) }
             ?: BarStyle.SOLID
+
+
+        fun Int.format(): String {
+            val format = DecimalFormat("#,###")
+            val decimalFormatSymbols = format.decimalFormatSymbols
+            decimalFormatSymbols.groupingSeparator = '.'
+            format.decimalFormatSymbols = decimalFormatSymbols
+            return format.format(this)
+        }
     }
 }

--- a/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
@@ -86,18 +86,10 @@ class Utils {
             }
         }
 
-        fun getBarColor(str : String?) : BarColor {
-            BarColor.entries.forEach {
-                if (it.name == str) return it
-            }
-            return BarColor.GREEN
-        }
+        fun getBarColor(str : String?) = BarColor.entries.firstOrNull { it.name.equals(str, true) }
+            ?: BarColor.GREEN
 
-        fun getBarStyle(str : String?) : BarStyle {
-            BarStyle.entries.forEach {
-                if (it.name == str) return it
-            }
-            return BarStyle.SOLID
-        }
+        fun getBarStyle(str : String?) = BarStyle.entries.firstOrNull { it.name.equals(str, true) }
+            ?: BarStyle.SOLID
     }
 }

--- a/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
@@ -7,6 +7,8 @@ import net.md_5.bungee.api.chat.ComponentBuilder
 import net.md_5.bungee.api.chat.HoverEvent
 import net.minevn.dotman.DotMan
 import org.bukkit.Bukkit
+import org.bukkit.boss.BarColor
+import org.bukkit.boss.BarStyle
 import org.bukkit.command.CommandSender
 import org.bukkit.scheduler.BukkitTask
 import java.util.logging.Level
@@ -82,6 +84,20 @@ class Utils {
                 }
                 create()
             }
+        }
+
+        fun getBarColor(str : String?) : BarColor {
+            BarColor.entries.forEach {
+                if (it.name == str) return it
+            }
+            return BarColor.GREEN
+        }
+
+        fun getBarStyle(str : String?) : BarStyle {
+            BarStyle.entries.forEach {
+                if (it.name == str) return it
+            }
+            return BarStyle.SOLID
         }
     }
 }

--- a/dotman-plugin/src/main/resources/mocnaptong.yml
+++ b/dotman-plugin/src/main/resources/mocnaptong.yml
@@ -1,0 +1,26 @@
+# Mốc nạp tổng và các lệnh thực thi khi đạt mốc
+# Có thể dùng cho: Server booster, tiến độ nạp, ...
+mocnaptong:
+- type: all # Toàn thời gian
+  # Lưu ý: Đối với mốc nạp toàn thời gian, tiền độ donate sẽ tính theo donate của server từ trước đến nay.
+  #bossbar: 'Donate server: %current%/%target% VNĐ' # Bossbar hiển thị tiến độ (bỏ comment để hiển thị)
+  #from: 0 # mức hiển bossbar
+  bossbar-style: GREEN
+  bossbar-color: SEGMENTED_10
+  amount: 10000000 # Giá trị tích lũy
+  commands: # Các lệnh chạy cho player khi đạt mốc
+    - 'say Donate của server đã đạt 10 triệu!'
+
+- type: week # Mốc nạp tuần (tính năng premium)
+  bossbar-style: GREEN
+  bossbar-color: SEGMENTED_10
+  amount: 1000000
+  commands:
+    - 'say Tuần này donate của server đã đạt 1 triệu!'
+
+- type: month # Mốc nạp tháng (tính năng premium)
+  bossbar-style: GREEN
+  bossbar-color: SEGMENTED_10
+  amount: 5000000
+  commands:
+    - 'say Tháng này donate của server đã đạt 5 triệu!'

--- a/dotman-plugin/src/main/resources/mocnaptong.yml
+++ b/dotman-plugin/src/main/resources/mocnaptong.yml
@@ -5,22 +5,22 @@ mocnaptong:
   # Lưu ý: Đối với mốc nạp toàn thời gian, tiền độ donate sẽ tính theo donate của server từ trước đến nay.
   #bossbar: 'Donate server: %current%/%target% VNĐ' # Bossbar hiển thị tiến độ (bỏ comment để hiển thị)
   #from: 0 # mức hiển bossbar
-  bossbar-style: GREEN
-  bossbar-color: SEGMENTED_10
+  bossbar-color: GREEN
+  bossbar-style: SEGMENTED_10
   amount: 10000000 # Giá trị tích lũy
   commands: # Các lệnh chạy cho player khi đạt mốc
     - 'say Donate của server đã đạt 10 triệu!'
 
 - type: week # Mốc nạp tuần (tính năng premium)
-  bossbar-style: GREEN
-  bossbar-color: SEGMENTED_10
+  bossbar-color: GREEN
+  bossbar-style: SEGMENTED_10
   amount: 1000000
   commands:
     - 'say Tuần này donate của server đã đạt 1 triệu!'
 
 - type: month # Mốc nạp tháng (tính năng premium)
-  bossbar-style: GREEN
-  bossbar-color: SEGMENTED_10
+  bossbar-color: GREEN
+  bossbar-style: SEGMENTED_10
   amount: 5000000
   commands:
     - 'say Tháng này donate của server đã đạt 5 triệu!'


### PR DESCRIPTION
## Nội dung
- Tính năng khách hàng yêu cầu: Mốc nạp toàn server
  - Mục đích: Để theo dõi tiến độ donate, hoặc phần thưởng chung cho toàn server như booster
- Hỗ trợ bossbar
- Giảm thời gian update top còn 1 phút

## Tests
- Bossbar
- Reload command
- Nạp thẻ