### PR TITLE
bug: fix import bossbar on 1.8

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/Milestones.kt
@@ -3,14 +3,12 @@ package net.minevn.dotman.config
 import net.minevn.dotman.DotMan
 import net.minevn.dotman.TOP_KEY_DONATE_TOTAL
 import net.minevn.dotman.database.PlayerDataDAO
+import net.minevn.dotman.utils.BukkitBossBar
 import net.minevn.dotman.utils.Utils.Companion.format
 import net.minevn.dotman.utils.Utils.Companion.info
 import net.minevn.dotman.utils.Utils.Companion.warning
 import net.minevn.libs.bukkit.runSync
 import org.bukkit.Bukkit
-import org.bukkit.boss.BarColor
-import org.bukkit.boss.BarStyle
-import org.bukkit.boss.BossBar
 import org.bukkit.entity.Player
 import org.bukkit.scheduler.BukkitTask
 
@@ -61,15 +59,14 @@ class Milestones : FileConfig("mocnap") {
     fun getAll() = components.toList()
 
     class Component(val type: String, val amount: Int, val commands: List<String>, val bossBar: String? = null,
-                    val from: Int = 0, barColor : BarColor = BarColor.GREEN,
-                    barStyle: BarStyle = BarStyle.SEGMENTED_10) {
+                    val from: Int = 0, barColor: String = "GREEN", barStyle: String = "SEGMENTED_10") {
 
-        var bar: BossBar? = null
+        var bar: BukkitBossBar? = null
         var barTask: BukkitTask? = null; private set
 
         init {
             if (bossBar != null) {
-                bar = Bukkit.createBossBar("§r", barColor, barStyle).apply {
+                bar = BukkitBossBar("r", barColor, barStyle).apply {
                     isVisible = false
                     barTask = Bukkit.getScheduler().runTaskTimerAsynchronously(DotMan.instance, Runnable {
                         val current = PlayerDataDAO.getInstance().getSumData("${TOP_KEY_DONATE_TOTAL}_$type")

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/MilestonesMaster.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/MilestonesMaster.kt
@@ -1,8 +1,6 @@
 package net.minevn.dotman.config
 
 import net.minevn.dotman.config.Milestones.Component
-import net.minevn.dotman.utils.Utils.Companion.getBarColor
-import net.minevn.dotman.utils.Utils.Companion.getBarStyle
 import net.minevn.dotman.utils.Utils.Companion.info
 import net.minevn.dotman.utils.Utils.Companion.warning
 import net.minevn.libs.bukkit.color
@@ -23,8 +21,8 @@ class MilestonesMaster : FileConfig("mocnaptong") {
                 val type = it["type"]
                 val bossBar = (it.getOrDefault("bossbar", null) as String?)?.color()
                 val from = it.getOrDefault("from", 0) as Int
-                val barColor = getBarColor(it.getOrDefault("bossbar-color", null) as String?)
-                val barStyle = getBarStyle(it.getOrDefault("bossbar-style", null) as String?)
+                val barColor = it.getOrDefault("bossbar-color", "GREEN") as String
+                val barStyle = it.getOrDefault("bossbar-style", "SEGMENTED_10") as String
 
                 if (type !in listOf("all", "week", "month")) {
                     warning("Loại mốc nạp \"$type\" không hợp lệ. Chỉ chấp nhận all, week, month")

--- a/dotman-plugin/src/main/java/net/minevn/dotman/utils/BukkitBossBar.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/utils/BukkitBossBar.kt
@@ -1,0 +1,12 @@
+package net.minevn.dotman.utils
+
+import org.bukkit.Bukkit
+import org.bukkit.boss.BarColor
+import org.bukkit.boss.BarStyle
+import org.bukkit.boss.BossBar
+
+/**
+ * Vì 1.8 không có BossBar nên phải tạo class này
+ */
+class BukkitBossBar(title: String, color: String, style: String) : BossBar
+by Bukkit.createBossBar(title, BarColor.valueOf(color), BarStyle.valueOf(style))

--- a/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/utils/Utils.kt
@@ -9,8 +9,6 @@ import net.minevn.dotman.DotMan
 import net.minevn.libs.anvilgui.AnvilGUI
 import net.minevn.libs.xseries.XMaterial
 import org.bukkit.Bukkit
-import org.bukkit.boss.BarColor
-import org.bukkit.boss.BarStyle
 import org.bukkit.command.CommandSender
 import org.bukkit.scheduler.BukkitTask
 import java.text.DecimalFormat
@@ -88,13 +86,6 @@ class Utils {
                 create()
             }
         }
-
-        fun getBarColor(str : String?) = BarColor.entries.firstOrNull { it.name.equals(str, true) }
-            ?: BarColor.GREEN
-
-        fun getBarStyle(str : String?) = BarStyle.entries.firstOrNull { it.name.equals(str, true) }
-            ?: BarStyle.SOLID
-
 
         fun Int.format(): String {
             val format = DecimalFormat("#,###")


### PR DESCRIPTION
## Nội dung
- Fix lỗi không chạy được trên 1.8 vì không import được bossbar

## Tests
- [x] Loại bỏ toàn bộ import đến package `org.bukkit.boss` (trừ class `BukkitBosBar`)
- [x] Build được
- [x] Chạy được trên 1.20 & có bossbar
  - Lười test trên 1.8 mà chắc không sao. Tại ai quan tâm monke. 