### PR TITLE
Bump PlaceholderAPI + cập nhật repo mới

### DIFF
--- a/dotman-plugin/build.gradle.kts
+++ b/dotman-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     maven("https://oss.sonatype.org/content/repositories/snapshots/")
     maven("https://repo.dmulloy2.net/repository/public/")
     maven("https://jitpack.io")
-    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
+    maven("https://repo.extendedclip.com/releases")
     maven {
         setUrl("http://pack.minevn.net/repo/")
         isAllowInsecureProtocol = true
@@ -22,7 +22,7 @@ dependencies {
     // libs
     compileOnly("net.minevn:minevnlib-plugin:1.1.3")
     compileOnly("minevn.depend:playerpoints:3.2.6")
-    compileOnly("me.clip:placeholderapi:2.11.3")
+    compileOnly("me.clip:placeholderapi:2.11.6")
 
     // JUnit
     testImplementation(platform("org.junit:junit-bom:5.9.1"))


### PR DESCRIPTION
HelpChat cập nhật sang repo mới và gỡ PlaceholderAPI 2.11.5 trở xuống khỏi repo.

PR này sẽ giúp fix lỗi không tìm được PAPI khi build & bị fail khi ci/cd chạy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded PlaceholderAPI dependency to version 2.11.6 for improved functionality and stability.
  
- **Chores**
	- Updated repository URLs to enhance reliability and access to stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->