### PR TITLE
Feature: Lên danh sách khuyến mãi

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/DotMan.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/DotMan.kt
@@ -36,6 +36,7 @@ class DotMan : MineVNPlugin() {
     lateinit var milestones: Milestones private set
     lateinit var milestonesMaster: MilestonesMaster private set
     lateinit var discord: Discord private set
+    lateinit var plannedExtras: PlannedExtras private set
 
     override fun onEnable() {
         instance = this
@@ -80,6 +81,7 @@ class DotMan : MineVNPlugin() {
         }
         milestonesMaster = MilestonesMaster()
         discord = Discord()
+        plannedExtras = PlannedExtras()
 
         // init Gui configs
         CardTypeUI()

--- a/dotman-plugin/src/main/java/net/minevn/dotman/commands/AdminCmd.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/commands/AdminCmd.kt
@@ -233,8 +233,13 @@ class AdminCmd {
                 }
 
                 if (point == null) {
-                    val isExtra = cfg.extraUntil > System.currentTimeMillis()
-                    val extraRate = if (isExtra) cfg.extraRate else 0.0
+                    // Giá trị khuyến mãi cũ từ config.yml
+                    val legacyExtraRate = if (cfg.extraUntil > System.currentTimeMillis()) cfg.extraRate else 0.0
+
+                    // Giá trị khuyến mãi chính thức: Nếu có khuyến mãi planned thì dùng, không thì lấy legacyExtraRate
+                    val plannedExtra = main.plannedExtras.getCurrentExtra()
+                    val extraRate = plannedExtra?.rate ?: legacyExtraRate
+
                     val pointPer1K = cfg.manualBase + cfg.manualExtra + (cfg.manualBase * extraRate)
                     point = (amount / 1000) * pointPer1K
                 }

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/PlannedExtras.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/PlannedExtras.kt
@@ -54,13 +54,6 @@ class PlannedExtras : FileConfig("khuyenmai") {
             .maxByOrNull { it.rate }
     }
 
-    /**
-     * Lấy tất cả khuyến mãi
-     *
-     * @return Danh sách khuyến mãi
-     */
-    fun getAll() = components.toList()
-
     class Component(val name: String, val rate: Double, val from: Long, val to: Long) {
         /**
          * Kiểm tra xem khuyến mãi có đang hoạt động tại thời điểm hiện tại không

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/PlannedExtras.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/PlannedExtras.kt
@@ -1,0 +1,94 @@
+package net.minevn.dotman.config
+
+import net.minevn.dotman.utils.Utils.Companion.info
+import net.minevn.dotman.utils.Utils.Companion.warning
+import java.text.SimpleDateFormat
+
+class PlannedExtras : FileConfig("khuyenmai") {
+
+    private var components: List<Component> = emptyList()
+    private val dateFormat = SimpleDateFormat("dd/MM/yyyy HH:mm")
+
+    init {
+        loadComponents()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadComponents() {
+        components = (config.getList("khuyenmai") ?: emptyList()).mapNotNull {
+            try {
+                it as Map<*, *>
+                val name = it["name"] as String
+                val rate = it["rate"] as Double
+                val fromStr = it["from"] as String
+                val toStr = it["to"] as String
+
+                val from = dateFormat.parse(fromStr).time
+                val to = dateFormat.parse(toStr).time
+
+                Component(name, rate, from, to)
+            } catch (e: Exception) {
+                e.warning("Có một khuyến mãi không hợp lệ: ${e.message}")
+                null
+            }
+        }
+
+        info("Đã nạp ${components.size} khuyến mãi.")
+    }
+
+    override fun reload() {
+        super.reload()
+        loadComponents()
+    }
+
+    /**
+     * Lấy khuyến mãi đang hoạt động tại thời điểm hiện tại
+     * Nếu có nhiều khuyến mãi cùng lúc, sẽ lấy khuyến mãi có tỉ lệ cao nhất
+     *
+     * @return Khuyến mãi đang hoạt động, hoặc null nếu không có
+     */
+    fun getCurrentExtra(): Component? {
+        val currentTime = System.currentTimeMillis()
+        return components
+            .filter { it.from <= currentTime && it.to >= currentTime }
+            .maxByOrNull { it.rate }
+    }
+
+    /**
+     * Lấy tất cả khuyến mãi
+     *
+     * @return Danh sách khuyến mãi
+     */
+    fun getAll() = components.toList()
+
+    class Component(val name: String, val rate: Double, val from: Long, val to: Long) {
+        /**
+         * Kiểm tra xem khuyến mãi có đang hoạt động tại thời điểm hiện tại không
+         *
+         * @return true nếu khuyến mãi đang hoạt động
+         */
+        fun isActive(): Boolean {
+            val currentTime = System.currentTimeMillis()
+            return from <= currentTime && to >= currentTime
+        }
+
+        /**
+         * Tính toán số tiền khuyến mãi dựa trên số tiền gốc
+         *
+         * @param baseAmount Số tiền gốc
+         * @return Số tiền sau khi áp dụng khuyến mãi
+         */
+        fun calculateAmount(baseAmount: Int): Int {
+            return baseAmount + (baseAmount * rate).toInt()
+        }
+
+        /**
+         * Lấy phần trăm khuyến mãi
+         *
+         * @return Phần trăm khuyến mãi
+         */
+        fun getPercentage(): Int {
+            return (rate * 100).toInt()
+        }
+    }
+}

--- a/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
@@ -114,11 +114,18 @@ abstract class CardProvider {
         var amount = card.price.getPointAmount()
         val commands = card.price.getCommands().map { it.replace("%PLAYER%", player.name) }
         val config = main.config
-        val extraRate = config.extraRate
         var extraPercent = 0
-        if (extraRate > 0 && config.extraUntil > System.currentTimeMillis()) {
+        
+        // Check for planned extras first
+        val plannedExtra = main.plannedExtras.getCurrentExtra()
+        if (plannedExtra != null) {
+            amount = plannedExtra.calculateAmount(amount)
+            extraPercent = plannedExtra.getPercentage()
+        } 
+        // If no planned extra, check legacy extra
+        else if (config.extraRate > 0 && config.extraUntil > System.currentTimeMillis()) {
             amount += (amount * config.extraRate).toInt()
-            extraPercent = (extraRate * 100).toInt()
+            extraPercent = (config.extraRate * 100).toInt()
         }
         DotMan.instance.playerPoints.api.give(player.uniqueId, amount)
 

--- a/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/providers/CardProvider.kt
@@ -121,9 +121,8 @@ abstract class CardProvider {
         if (plannedExtra != null) {
             amount = plannedExtra.calculateAmount(amount)
             extraPercent = plannedExtra.getPercentage()
-        } 
-        // If no planned extra, check legacy extra
-        else if (config.extraRate > 0 && config.extraUntil > System.currentTimeMillis()) {
+        } else if (config.extraRate > 0 && config.extraUntil > System.currentTimeMillis()) {
+            // If no planned extra, check legacy extra
             amount += (amount * config.extraRate).toInt()
             extraPercent = (config.extraRate * 100).toInt()
         }

--- a/dotman-plugin/src/main/resources/khuyenmai.yml
+++ b/dotman-plugin/src/main/resources/khuyenmai.yml
@@ -1,0 +1,29 @@
+# Đặt lịch khuyến mãi
+# Tại file này, bạn có thể lên kế hoạch cho các khuyến mãi trong tương lai
+# Mỗi gạch đầu dòng là một kế hoạch khuyến mãi
+#
+# Các tùy chọn gồm có:
+# * name: Tên khuyến mãi
+# * rate: Tỉ lệ khuyến mãi, tính theo công thức sau:
+#   * 0: Không có khuyến mãi
+#   * 0.5: Khuyến mãi 50%, ví dụ: nạp 100k được 150k
+#   * 1: Khuyến mãi 100%, ví dụ: nạp 100k được 200k
+#   * 1.5: Khuyến mãi 150%, ví dụ: nạp 100k được 250k
+# * from: Ngày bắt đầu khuyến mãi (định dạng dd/MM/yyyy HH:mm)
+# * to: Ngày kết thúc khuyến mãi (định dạng dd/MM/yyyy HH:mm)
+#
+# Khuyến mãi ở file này sẽ được ưu tiên so với khuyến mãi được thiết lập ở file config.yml
+#
+# Trong trường hợp tại một thời điểm có nhiều khuyến mãi cùng lúc, khuyến mãi có tỉ lệ cao nhất sẽ được ưu tiên
+
+- name: '&aNgày Giải Phóng Miền Nam và Quốc tế Lao Động'
+  rate: 1.0
+  from: 30/04/2024 00:00
+  to: 01/05/2024 23:59
+
+- name: '&aNgày Quốc khánh Việt Nam'
+  rate: 1.0
+  from: 02/09/2024 00:00
+  to: 03/09/2024 23:59
+
+


### PR DESCRIPTION
https://git.minevn.net/kitchen/plan/-/issues/60

# Tổng quan
Cho phép server admin lên danh sách khuyên mãi tại file `khuyenmai.yml`  

Nội dung file mẫu (dùng năm 2024 làm ví dụ)

```yaml
# Đặt lịch khuyến mãi
# Tại file này, bạn có thể lên kế hoạch cho các khuyến mãi trong tương lai
# Mỗi gạch đầu dòng là một kế hoạch khuyến mãi
#
# Các tùy chọn gồm có:
# * name: Tên khuyến mãi
# * rate: Tỉ lệ khuyến mãi, tính theo công thức sau:
#   * 0: Không có khuyến mãi
#   * 0.5: Khuyến mãi 50%, ví dụ: nạp 100k được 150k
#   * 1: Khuyến mãi 100%, ví dụ: nạp 100k được 200k
#   * 1.5: Khuyến mãi 150%, ví dụ: nạp 100k được 250k
# * from: Ngày bắt đầu khuyến mãi (định dạng dd/MM/yyyy HH:mm)
# * to: Ngày kết thúc khuyến mãi (định dạng dd/MM/yyyy HH:mm)
#
# Khuyến mãi ở file này sẽ được ưu tiên so với khuyến mãi được thiết lập ở file config.yml
#
# Trong trường hợp tại một thời điểm có nhiều khuyến mãi cùng lúc, khuyến mãi có tỉ lệ cao nhất sẽ được ưu tiên

- name: '&aNgày Giải Phóng Miền Nam và Quốc tế Lao Động'
  rate: 1.0
  from: 30/04/2024 00:00
  to: 01/05/2024 23:59

- name: '&aNgày Quốc khánh Việt Nam'
  rate: 1.0
  from: 02/09/2024 00:00
  to: 03/09/2024 23:59
```