### PR TITLE
added %server% placeholder to discord.yml

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/DotMan.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/DotMan.kt
@@ -154,7 +154,8 @@ class DotMan : MineVNPlugin() {
                 "%POINT_UNIT%" to config.pointUnit,
                 "%BALANCE%" to balance.toString(),
                 "%METHOD%" to type.typeName,
-                "%TIME%" to timeStr
+                "%TIME%" to timeStr,
+                "%SERVER%" to config.server
             )
             discord.webhooks.forEach { sender ->
                 sender.send(replacements)

--- a/dotman-plugin/src/main/resources/discord.yml
+++ b/dotman-plugin/src/main/resources/discord.yml
@@ -1,7 +1,7 @@
 # Cấu hình Discord Webhook cho DotMan
 # - Trường enabled mặc định là true nếu không khai báo. Đặt false để tạm tắt webhook.
 # - Có thể sử dụng placeholder sau trong content/embeds:
-#   %PLAYER%, %AMOUNT%, %POINT_AMOUNT%, %POINT_UNIT%, %BALANCE%, %METHOD%, %TIME%
+#   %PLAYER%, %AMOUNT%, %POINT_AMOUNT%, %POINT_UNIT%, %BALANCE%, %METHOD%, %TIME%, %SERVER%
 # - Màu (color) phải là chuỗi hex dạng "#RRGGBB" (ví dụ: "#58b9ff"). Nếu sai định dạng sẽ tự chuyển về trắng "#FFFFFF".
 # Bạn có thể dùng https://discohook.org/ để thiết kế
 


### PR DESCRIPTION
This pull request adds support for a new `%SERVER%` placeholder in Discord webhook messages, allowing the server name to be included in notifications. The change updates both the code that sends webhook messages and the documentation in the configuration file.

**Discord webhook placeholder improvements:**

* Added `%SERVER%` to the replacements map when sending Discord webhook messages in `DotMan.kt`, enabling server information to be included in notifications.
* Updated the placeholder documentation in `discord.yml` to mention the new `%SERVER%` placeholder, ensuring users are aware of its availability.
<img width="635" height="497" alt="image" src="https://github.com/user-attachments/assets/7da43ef3-a2dc-4162-b098-5a5f3f6c0055" />
