### PR TITLE
Fix unload placeholder khi dùng lệnh /papi reload

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/Expansion.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/Expansion.kt
@@ -13,7 +13,7 @@ class Expansion : PlaceholderExpansion() {
 
     override fun getAuthor() = "MineVN"
 
-    override fun getVersion() = "1.0"
+    override fun getVersion() = DotMan.instance.description.version.trim()
 
     @Suppress("NAME_SHADOWING")
     override fun onPlaceholderRequest(player: Player?, params: String): String? {

--- a/dotman-plugin/src/main/java/net/minevn/dotman/Expansion.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/Expansion.kt
@@ -15,6 +15,8 @@ class Expansion : PlaceholderExpansion() {
 
     override fun getVersion() = DotMan.instance.description.version.trim()
 
+    override fun persist() = true
+
     @Suppress("NAME_SHADOWING")
     override fun onPlaceholderRequest(player: Player?, params: String): String? {
         val params = params.lowercase()


### PR DESCRIPTION
Và đánh version papi theo version plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Plugin version now reports the actual plugin version dynamically instead of a fixed default value.
  * Placeholder persistence is now explicitly enabled for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->