### PR TITLE
Sửa payload Discord webhook khi bỏ trống identity

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/discord/Webhook.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/discord/Webhook.kt
@@ -8,11 +8,21 @@ import net.minevn.dotman.utils.applyReplacements
 class Webhook(private val url: String, private val payload: Map<*, *>) {
     fun send(replacements: Map<String, String>) {
         val processedPayload = applyReplacements(payload, replacements) as? Map<*, *> ?: return
-        val json = processedPayload.toJson()
+        val json = processedPayload.withDiscordIdentity().toJson()
         try {
             post(url, "application/json", json)
         } catch (e: Exception) {
             e.warning("Gửi Discord webhook thất bại")
         }
+    }
+
+    private fun Map<*, *>.withDiscordIdentity(): Map<*, *> {
+        val username = this["username"] as? String
+        val avatarUrl = this["avatar_url"] as? String
+        if (!username.isNullOrBlank() && !avatarUrl.isNullOrBlank()) {
+            return this
+        }
+
+        return this.filterKeys { it != "username" && it != "avatar_url" }
     }
 }

--- a/dotman-plugin/src/main/resources/discord.yml
+++ b/dotman-plugin/src/main/resources/discord.yml
@@ -1,8 +1,8 @@
-# Cấu hình Discord Webhook cho DotMan
-# - Trường enabled mặc định là true nếu không khai báo. Đặt false để tạm tắt webhook.
+# Cấu hình gửi thông báo nạp tiền qua Discord Webhook
 # - Có thể sử dụng placeholder sau trong content/embeds:
 #   %PLAYER%, %AMOUNT%, %POINT_AMOUNT%, %POINT_UNIT%, %BALANCE%, %METHOD%, %TIME%, %SERVER%
 # - Màu (color) phải là chuỗi hex dạng "#RRGGBB" (ví dụ: "#58b9ff"). Nếu sai định dạng sẽ tự chuyển về trắng "#FFFFFF".
+# - Nếu đã setup sẵn username và avatar bên trong Discord (Integrations -> Webhooks), hãy bỏ trống "" mục username và avatar_url.
 # Bạn có thể dùng https://discohook.org/ để thiết kế
 
 discord-hooks:
@@ -51,8 +51,8 @@ discord-hooks:
   - enabled: false
     url: https://discord.com/api/webhooks/123456/webhook-token
     payload:
-      username: "MineVN"
-      avatar_url: "https://i.imgur.com/tdZ2LxY.png"
+      username: ""
+      avatar_url: ""
       content:
         - "Thông báo nạp tiền thành công!"
         - "Thời gian: %TIME%"


### PR DESCRIPTION
- Bỏ username và avatar_url khỏi payload nếu không có đủ cả hai giá trị
- Cập nhật discord.yml để hướng dẫn dùng identity mặc định của webhook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord webhook handling by omitting incomplete custom identity details, preventing invalid username or avatar configurations from being sent.
* **Documentation**
  * Updated webhook configuration guidance and defaults to clarify when username and avatar fields should be left empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->