### PR TITLE
Broadcast announce-charge message for manual deposit command too

### DIFF
--- a/dotman-plugin/src/main/java/net/minevn/dotman/commands/AdminCmd.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/commands/AdminCmd.kt
@@ -281,6 +281,16 @@ class AdminCmd {
                         sender.send("§aĐã nạp §d${amount.format()} VNĐ §acho người chơi §b$playerName " +
                                 "§avà nhận §b${point.toInt()} §apoint")
 
+                        if (cfg.announceCharge) {
+                            main.language.manualChargedAnnounce.forEach {
+                                it  .replace("%PLAYER%", playerName)
+                                    .replace("%CARD_PRICE%", amount.toString())
+                                    .replace("%AMOUNT%", point.toInt().toString())
+                                    .replace("%POINT_UNIT%", cfg.pointUnit)
+                                    .apply { Bukkit.broadcastMessage(this) }
+                            }
+                        }
+
                         if (extraRatePercent != 0) {
                             sender.send("§aNgười chơi được khuyến mãi §b$extraRatePercent% §agiá trị nạp.")
                             if (plannedExtraName != null) {

--- a/dotman-plugin/src/main/java/net/minevn/dotman/config/Language.kt
+++ b/dotman-plugin/src/main/java/net/minevn/dotman/config/Language.kt
@@ -20,6 +20,7 @@ class Language : FileConfig("messages") {
     val cardChargedWithExtraPlanned = get("card-charged-with-extra-planned")
     val cardChargedSent = getList("card-charged-sent")
     val cardChargedAnnounce = getList("card-charged-announce")
+    val manualChargedAnnounce = getList("manual-charged-announce")
     val cardChargedFailed = getList("card-charged-failed")
     val cardChargedError = getList("card-charged-error")
 

--- a/dotman-plugin/src/main/resources/config.yml
+++ b/dotman-plugin/src/main/resources/config.yml
@@ -93,7 +93,7 @@ database:
     password: '123'
     database: dotman
 
-# Bật/tắt tính năng thông báo người chơi khác khi nạp thẻ thành công
+# Bật/tắt tính năng thông báo người chơi khác khi nạp thẻ hoặc nạp thủ công thành công
 announce-charge: true
 
 # Bật/tắt tính năng kiểm tra cập nhật phiên bản mới

--- a/dotman-plugin/src/main/resources/messages.yml
+++ b/dotman-plugin/src/main/resources/messages.yml
@@ -25,6 +25,9 @@ card-charged-sent:
 card-charged-announce:
   - '%PREFIX% &aNgười chơi &b%PLAYER% &ađã nạp thẻ mệnh giá &e%CARD_PRICE% VNĐ &avà nhận được &e%AMOUNT% %POINT_UNIT%'
 
+manual-charged-announce:
+  - '%PREFIX% &aNgười chơi &b%PLAYER% &ađã nạp &e%CARD_PRICE% VNĐ &avà nhận được &e%AMOUNT% %POINT_UNIT%'
+
 card-charged-failed:
   - '%PREFIX% &cNạp thẻ thất bại: %ERROR%'
   - '&cVui lòng liên hệ với admin để được hỗ trợ.'


### PR DESCRIPTION
The napthucong/manual admin command gave points without ever checking
announce-charge, so server-wide announcements only fired for card
top-ups. Reuse the same config toggle and broadcast a manual-specific
message (manual-charged-announce) after a successful manual deposit.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017yu9SFZD9cjfwuYWXSwYP2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable server-wide announcements for successful manual top-ups.
  * Announcements can include the player’s name, card value, and credited amount or points.
  * Added a customizable message template for manual top-up notifications.

* **Configuration**
  * The existing announcement setting now applies to both card-based and manual top-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->