### PR TITLE
Bump các thư viện, Java 17 và paper-api 1.21.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: "gradle"
 
       - name: Build DotMan
@@ -32,4 +32,4 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: "DotMan"
-          path: ./dotman-plugin/build/libs/*.jar
+          path: ./dotman-plugin/build/libs/DotMan.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: "gradle"
 
       - name: Build DotMan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: "gradle"
 
       - name: Build DotMan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: "gradle"
 
       - name: Build DotMan
@@ -25,4 +25,4 @@ jobs:
       - name: Attach JARs to the Release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./dotman-plugin/build/libs/*.jar
+          files: ./dotman-plugin/build/libs/DotMan.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -21,8 +23,17 @@ allprojects {
     }
 
     java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    configurations.configureEach {
+        if (isCanBeResolved) {
+            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 21)
+        }
     }
 
     tasks.withType<JavaCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
-    kotlin("jvm") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
 }
 
 allprojects {
@@ -21,11 +21,14 @@ allprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
+
     tasks.withType<JavaCompile>().configureEach {
-        options.release.set(8)
+        options.release.set(17)
     }
-    kotlin.compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+
+    kotlin.compilerOptions.jvmTarget = JvmTarget.JVM_17
+
 }

--- a/dotman-plugin/build.gradle.kts
+++ b/dotman-plugin/build.gradle.kts
@@ -6,10 +6,10 @@ repositories {
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://repo.codemc.org/repository/maven-public/")
     maven("https://oss.sonatype.org/content/repositories/snapshots/")
-    maven("https://repo.dmulloy2.net/repository/public/")
     maven("https://jitpack.io")
     maven("https://repo.extendedclip.com/releases")
     maven("https://repo.minevn.net/releases/")
+    maven("https://repo.rosewooddev.io/repository/public/")
 }
 
 dependencies {
@@ -17,10 +17,10 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
 
     // libs
-    compileOnly("net.minevn:minevnlib-plugin:26.1")
-    compileOnly("minevn.depend:playerpoints:3.2.6")
-    compileOnly("me.clip:placeholderapi:2.11.6")
-    implementation("org.bstats:bstats-bukkit:3.0.2")
+    compileOnly("net.minevn:minevnlib-plugin:26.1.2")
+    compileOnly("org.black_ixx:playerpoints:3.3.5")
+    compileOnly("me.clip:placeholderapi:2.12.3")
+    implementation("org.bstats:bstats-bukkit:3.2.1")
 
     // JUnit
     testImplementation(platform("org.junit:junit-bom:5.9.1"))

--- a/dotman-plugin/build.gradle.kts
+++ b/dotman-plugin/build.gradle.kts
@@ -3,18 +3,18 @@ plugins {
 }
 
 repositories {
-    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://repo.codemc.org/repository/maven-public/")
     maven("https://oss.sonatype.org/content/repositories/snapshots/")
     maven("https://jitpack.io")
     maven("https://repo.extendedclip.com/releases")
     maven("https://repo.minevn.net/releases/")
     maven("https://repo.rosewooddev.io/repository/public/")
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {
-    // spigot
-    compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
+    // paper
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
 
     // libs
     compileOnly("net.minevn:minevnlib-plugin:26.1.2")


### PR DESCRIPTION
- Bump các thư viện: MineVNLib, PlayerPoints, PlaceholderAPI, bStats
- Đổi PlayerPoints về repo gốc
- Dùng Java 17 để build project, drop Java cổ đại
- Bump lên paper-api 1.21.11 - phục vụ cho tính năng mới sau này (Dialog).

Sau khi test, plugin có thể chạy trên Java 17+, MC 1.12.2+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build and release process to use Java 21.
  - Improved compatibility with modern Java and Minecraft server environments.
  - Refreshed plugin integrations and supporting libraries.
  - Release packages now include the intended application artifact, making downloads more consistent.
  - Updated the Kotlin build tooling and raised the supported JVM baseline for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->